### PR TITLE
Do not exit 1 with empty WATCHDOGS_GITHUB_API_TOKEN

### DIFF
--- a/cmd/watchdogs/main.go
+++ b/cmd/watchdogs/main.go
@@ -64,16 +64,21 @@ func run(r io.Reader, w io.Writer, diffCmd string, diffStrip int, efms []string,
 	var ds watchdogs.DiffService
 
 	if ci != "" {
-		gs, isPR, err := githubService(ci)
-		if err != nil {
-			return err
-		}
-		if !isPR {
-			fmt.Fprintf(os.Stderr, "this is not PullRequest build. CI: %v\n", ci)
+		if os.Getenv("WATCHDOGS_GITHUB_API_TOKEN") != "" {
+			gs, isPR, err := githubService(ci)
+			if err != nil {
+				return err
+			}
+			if !isPR {
+				fmt.Fprintf(os.Stderr, "this is not PullRequest build. CI: %v\n", ci)
+				return nil
+			}
+			cs = gs
+			ds = gs
+		} else {
+			fmt.Fprintf(os.Stderr, "WATCHDOGS_GITHUB_API_TOKEN is not set\n")
 			return nil
 		}
-		cs = gs
-		ds = gs
 	} else {
 		// local
 		cs = watchdogs.NewCommentWriter(w)

--- a/cmd/watchdogs/main_test.go
+++ b/cmd/watchdogs/main_test.go
@@ -28,10 +28,8 @@ func TestRun_travis(t *testing.T) {
 		}
 	}()
 
-	if err := run(nil, nil, "", 0, nil, "ciname"); err == nil {
-		t.Error("error expected but got nil")
-	} else {
-		t.Log(err)
+	if err := run(nil, nil, "", 0, nil, "ciname"); err != nil {
+		t.Errorf("got an unexpected error: %v", err)
 	}
 
 	os.Setenv("WATCHDOGS_GITHUB_API_TOKEN", "<WATCHDOGS_GITHUB_API_TOKEN>")


### PR DESCRIPTION
Travis CI and Circle CI fail with pull request build from forked
repositories because we cannot encrypted environment variables in the
build from forked repositories.